### PR TITLE
Query builder endpoints for CPVs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 env:
   global:
-    - NODE_ENV=test
+    - NODE_ENV=testing
     - URL=http://localhost:10010
     - ORIENTDB_HOST=localhost
     - ORIENTDB_PORT=2424

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/tenders-exposed/elvis-backend-node/badge.svg?branch=master)](https://coveralls.io/github/tenders-exposed/elvis-backend-node?branch=master)
 
-Search and visualize public procurements for EU countries http://elvis.tenders.exposed/
+Search and visualize public procurements for EU countries http://tenders.exposed/
 
 Previously, elvis.tenders.exposed was powered by tenders-exposed/elvis-backend but we decided to rewrite it completely because:
 

--- a/api/controllers/account.js
+++ b/api/controllers/account.js
@@ -44,7 +44,7 @@ function createAccount(req, res) {
       config.activation.expire,
     ))
     .then((token) => {
-      if (config.env !== 'test') {
+      if (config.env !== 'testing') {
         return new MailGun().sendEmail({
           to: userEmail,
           subject: 'Registration',
@@ -192,7 +192,7 @@ function forgotPassword(req, res) {
     })
     .catch((err) => formatError(err, req, res))
     .then((token) => {
-      if (config.env !== 'test') {
+      if (config.env !== 'testing') {
         return new MailGun().sendEmail({
           to: email,
           subject: 'Forgot password',

--- a/api/controllers/cpvs.js
+++ b/api/controllers/cpvs.js
@@ -6,14 +6,54 @@ const config = require('../../config/default');
 const formatError = require('../helpers/errorFormatter');
 
 function listCpvs(req, res) {
-  const countries = req.swagger.params.countries.value;
-  config.db.select().from('CPV').all()
-    .then((cpvs) => res.status(codes.SUCCESS).json({
-      cpvs: _.map(cpvs, (cpv) => _.pick(cpv, ['code', 'xName', 'xNumberDigits'])),
+  const swaggerParams = _.pickBy(
+    _.mapValues(req.swagger.params, 'value'),
+    (val) => !(_.isUndefined(val)),
+  );
+  let cpvs;
+  if (_.isEmpty(swaggerParams)) {
+    cpvs = config.db.select().from('CPV').all();
+  } else {
+    const queryCriteria = [];
+    const queryParams = {};
+    if (swaggerParams.countries) {
+      queryCriteria.push('{ as: bids,  where: (xCountry in :countries) }');
+      queryParams.countries = swaggerParams.countries;
+    }
+    if (swaggerParams.years) {
+      queryCriteria.push('{ as: bids,  where: (xYear in :years) }');
+      queryParams.years = swaggerParams.years;
+    }
+    if (swaggerParams.buyers) {
+      queryCriteria.push(`{ as: bids }.in('Awards')
+        { class: Buyer, where: (id in :buyers) }`);
+      queryParams.buyers = swaggerParams.buyers;
+    }
+    if (swaggerParams.bidders) {
+      queryCriteria.push(`{ as: bids }.in('Participates')
+        { class: Bidder, where: (id in :bidders) }`);
+      queryParams.bidders = swaggerParams.bidders;
+    }
+    const query = `SELECT expand(cpvs) FROM (
+      MATCH { class: Bid, as: bids },
+        ${_.join(queryCriteria, ',')},
+        { as: bids }.out('AppliedTo').in('Comprises').out('HasCPV'){ as: cpvs }
+      RETURN cpvs
+    )`;
+    cpvs = config.db.query(query, { params: queryParams });
+  }
+  return cpvs
+    .then((results) => res.status(codes.SUCCESS).json({
+      cpvs: _.map(results, (cpv) => formatCpv(cpv)),
     }))
-    .catch((err) => formatError(err));
+    .catch((err) => formatError(err, req, res));
+}
+
+function formatCpv(cpvNode) {
+  return _.pick(cpvNode, ['code', 'xName', 'xNumberDigits']);
 }
 
 module.exports = {
   listCpvs,
+  formatCpv,
 };

--- a/api/controllers/cpvs.js
+++ b/api/controllers/cpvs.js
@@ -1,12 +1,17 @@
 'use strict';
 
+const _ = require('lodash');
+const codes = require('../helpers/codes');
 const config = require('../../config/default');
+const formatError = require('../helpers/errorFormatter');
 
 function listCpvs(req, res) {
   const countries = req.swagger.params.countries.value;
-  console.log('Countries param:', countries); // eslint-disable-line no-console
-  config.db.select('code').from('CPV').all()
-    .then((cpvs) => res.json(cpvs));
+  config.db.select().from('CPV').all()
+    .then((cpvs) => res.status(codes.SUCCESS).json({
+      cpvs: _.map(cpvs, (cpv) => _.pick(cpv, ['code', 'xName', 'xNumberDigits'])),
+    }))
+    .catch((err) => formatError(err));
 }
 
 module.exports = {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -41,16 +41,43 @@ paths:
       parameters:
         - name: countries
           in: query
-          description: Get only Cpvs from contracts from a certain country
+          description: Get only the CPVs of contracts from certain countries
           required: false
           type: array
           items:
             type: string
+        - name: years
+          in: query
+          description: Get only the CPVs of contracts from certain countries
+          required: false
+          type: array
+          items:
+            type: integer
+        - name: buyers
+          in: query
+          description: Get only the CPVs of contracts awarded by certain buyers
+          required: false
+          type: array
+          items:
+            type: string
+            format: uuid
+        - name: bidders
+          in: query
+          description: Get only the CPVs of contracts awarded to certain bidders
+          required: false
+          type: array
+          items:
+            type: string
+            format: uuid
       responses:
         "200":
           description: Success
           schema:
             $ref: "#/definitions/CpvIndex"
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         default:
           description: Error
           schema:
@@ -371,14 +398,6 @@ definitions:
       password:
         type: string
         description: Password string
-  ForgotPasswordRequest:
-    type: object
-    required:
-      - email
-    properties:
-      email:
-        type: string
-        format: email
   ResetPasswordRequest:
     type: object
     required:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -50,9 +50,7 @@ paths:
         "200":
           description: Success
           schema:
-            type: array
-            items:
-              $ref: "#/definitions/CpvResponse"
+            $ref: "#/definitions/CpvIndex"
         default:
           description: Error
           schema:
@@ -437,15 +435,28 @@ definitions:
       refreshToken:
         type: string
         description: Refresh token with long life
-
-  CpvResponse:
+  CpvIndex:
     type: object
+    properties:
+      cpvs:
+        type: array
+        items:
+          $ref: "#/definitions/Cpv"
+  Cpv:
     required:
       - code
+      - xName
+      - xNumberDigits
     properties:
       code:
         type: string
         description: CPV code
+      xName:
+        type: string
+        description: CPV name
+      xNumberDigits:
+        type: integer
+        description: Number of relevant digits in the CPV
   ErrorResponse:
     type: object
     required:

--- a/api/writers.js
+++ b/api/writers.js
@@ -44,7 +44,7 @@ async function writeTender(fullTenderRecord) {
   // TODO: Remove this filter by id after empty objects are excluded from the Digiwhist dumps
   const buyerNames = await Promise.map(
     _.filter(fullTenderRecord.buyers, (rawBuyer) => rawBuyer.id),
-    (rawBuyer) => upsertBuyer(transaction, rawBuyer, existingTenderID, tenderName, fullTenderRecord),
+    (rawBuyer) => upsertBuyer(transaction, rawBuyer, existingTenderID, tenderName, fullTenderRecord), // eslint-disable-line max-len
   );
 
   if (_.isUndefined(existingTender) === false) {

--- a/config/default.js
+++ b/config/default.js
@@ -23,7 +23,7 @@ const orientDBConfig = {
   username: process.env.ORIENTDB_USER,
   password: process.env.ORIENTDB_PASS,
 };
-if (config.env === 'test') {
+if (config.env === 'testing') {
   orientDBConfig.name = process.env.ORIENTDB_TEST_DB;
   orientDBConfig.storage = 'memory';
 } else {

--- a/extractors/bid.js
+++ b/extractors/bid.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const _ = require('lodash');
+const moment = require('moment');
 const priceExtractor = require('./price');
 
-function extractBid(bidAttrs, publications = []) {
+function extractBid(bidAttrs, tenderAttrs, lotAttrs) {
   return {
     isWinning: bidAttrs.isWinning,
     isSubcontracted: bidAttrs.isSubcontracted,
@@ -11,13 +12,23 @@ function extractBid(bidAttrs, publications = []) {
     isDisqualified: bidAttrs.isDisqualified,
     price: priceExtractor.extractPrice(bidAttrs.price),
     robustPrice: priceExtractor.extractPrice(bidAttrs.robustPrice),
+    xCountry: tenderAttrs.country,
+    xYear: extractYear(lotAttrs.awardDecisionDate),
     xTEDCANID: _
-      .chain(publications)
+      .chain((tenderAttrs.publications || []))
       .filter({ formType: 'CONTRACT_AWARD' })
       .head()
       .get('sourceId')
       .value(),
   };
+}
+
+function extractYear(awardDecisionDate) {
+  let year;
+  if (_.isNil(awardDecisionDate) === false) {
+    year = moment(awardDecisionDate).year();
+  }
+  return year;
 }
 
 module.exports = {

--- a/extractors/bidder.js
+++ b/extractors/bidder.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const helpers = require('./helpers');
 const indicatorExtractor = require('./indicator');
 
-function extractBidder(bidderAttrs, indicators = []) {
+function extractBidder(bidderAttrs, tenderAttrs = {}) {
   return {
     id: bidderAttrs.id,
     name: bidderAttrs.name,
@@ -13,7 +13,7 @@ function extractBidder(bidderAttrs, indicators = []) {
     isPublic: bidderAttrs.isPublic,
     xDigiwhistLastModified: helpers.formatTimestamp(bidderAttrs.modified),
     indicators: _
-      .filter(indicators, { relatedEntityId: bidderAttrs.id })
+      .filter((tenderAttrs.indicators || []), { relatedEntityId: bidderAttrs.id })
       .map((indicatorAttrs) => indicatorExtractor.extractIndicator(indicatorAttrs)),
   };
 }

--- a/extractors/buyer.js
+++ b/extractors/buyer.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const helpers = require('./helpers');
 const indicatorExtractor = require('./indicator');
 
-function extractBuyer(buyerAttrs, indicators = []) {
+function extractBuyer(buyerAttrs, tenderAttrs = {}) {
   return {
     id: buyerAttrs.id,
     name: buyerAttrs.name,
@@ -14,7 +14,7 @@ function extractBuyer(buyerAttrs, indicators = []) {
     isSubsidized: buyerAttrs.isSubsidized,
     xDigiwhistLastModified: helpers.formatTimestamp(buyerAttrs.modified),
     indicators: _
-      .filter(indicators, { relatedEntityId: buyerAttrs.id })
+      .filter((tenderAttrs.indicators || []), { relatedEntityId: buyerAttrs.id })
       .map((indicatorAttrs) => indicatorExtractor.extractIndicator(indicatorAttrs)),
   };
 }

--- a/extractors/cpv.js
+++ b/extractors/cpv.js
@@ -4,6 +4,7 @@ function extractCpv(cpvAttrs) {
   return {
     xName: cpvAttrs.name,
     code: cpvAttrs.code,
+    xNumberDigits: cpvAttrs.xNumberDigits,
   };
 }
 

--- a/migrations/m20171228_192049_add_numberDigits_to_cpv.js
+++ b/migrations/m20171228_192049_add_numberDigits_to_cpv.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.name = 'add xNumberDigits to cpv';
+
+exports.up = (db) => (
+  db.class.get('CPV')
+    .then((CPV) => {
+      CPV.property.create([
+        {
+          name: 'xNumberDigits',
+          type: 'Integer',
+        },
+      ]);
+    })
+);
+
+exports.down = (db) => (
+  db.class.get('CPV')
+    .then((CPV) => CPV.property.drop('xNumberDigits'))
+);

--- a/migrations/m20180103_133727_add_xCountry_xYear_to_Bid.js
+++ b/migrations/m20180103_133727_add_xCountry_xYear_to_Bid.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const Promise = require('bluebird');
+
+exports.name = 'add xCountry and xYear to Bid';
+
+exports.up = (db) => (
+  db.class.get('Bid')
+    .then((Bid) => {
+      Bid.property.create([
+        {
+          name: 'xYear',
+          type: 'Integer',
+        },
+        {
+          name: 'xCountry',
+          type: 'String',
+          mandatory: true,
+        },
+      ]);
+    })
+    .then(() => {
+      db.index.create({
+        name: 'Bid.xCountry',
+        type: 'NOTUNIQUE_HASH_INDEX',
+      });
+    })
+    .then(() => {
+      db.index.create({
+        name: 'Bid.xYear',
+        type: 'NOTUNIQUE_HASH_INDEX',
+      });
+    })
+);
+
+exports.down = (db) => (
+  db.class.get('Bid')
+    .then((Bid) => Promise.all([
+      db.index.drop('Bid.xCountry'),
+      db.index.drop('Bid.xYear'),
+      Bid.property.drop('xCountry'),
+      Bid.property.drop('xYear'),
+    ]))
+);
+

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "migrate": "node ./scripts/migrate.js",
     "lint": "eslint .",
-    "test": "NODE_ENV=test nyc ava --serial",
+    "test": "NODE_ENV=testing nyc ava --serial",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "import_data": "node ./scripts/import_data.js"
   },

--- a/passport/index.js
+++ b/passport/index.js
@@ -129,7 +129,7 @@ module.exports.twitterStrategyCallback = (token, tokenSecret, profile, cb) => {
 module.exports.configureStrategies = () => {
   passport.use(new LocalStrategy({ usernameField: 'email' }, module.exports.localStrategyCallback));
 
-  if (config.env !== 'test') {
+  if (config.env !== 'testing') {
     passport.use(new GitHubStrategy(
       {
         clientID: config.passport.github.clientId,

--- a/scripts/insert_cpvs.js
+++ b/scripts/insert_cpvs.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+const _ = require('lodash');
+const { URL } = require('url');
+const https = require('https');
+const Promise = require('bluebird');
+
+const config = require('../config/default');
+const codes = require('../api/helpers/codes');
+
+const cpvsURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpv_codes.json');
+
+function fetchCPVs() {
+  return new Promise((resolve, reject) => {
+    console.log('Fetching CPVs...');
+    https.get(cpvsURL, (res) => {
+      const { statusCode } = res;
+      if (statusCode !== codes.SUCCESS) {
+        throw new Error(`Request failed with status code: ${statusCode}`);
+      }
+
+      res.setEncoding('utf8');
+      let rawData = '';
+      res.on('data', (chunk) => { rawData += chunk; });
+      res.on('end', () => resolve(JSON.parse(rawData)));
+    }).on('error', (e) => {
+      reject(e);
+    });
+  });
+}
+
+function importCPVs() {
+  fetchCPVs()
+    .then((cpvList) => {
+      console.log('Upserting CPVs...');
+      return Promise.map(cpvList, (rawCpv) => {
+        const cpv = {
+          code: rawCpv.code,
+          xName: rawCpv.text,
+          xNumberDigits: rawCpv.number_digits,
+        };
+        return config.db.select().from('CPV')
+          .where({ code: cpv.code })
+          .one()
+          .then((existingCpv) => {
+            if (_.isUndefined(existingCpv)) {
+              return config.db.create('vertex', 'CPV')
+                .set(cpv)
+                .commit()
+                .one();
+            }
+            return config.db.update('CPV')
+              .set(cpv)
+              .where({ '@rid': existingCpv['@rid'] })
+              .return('AFTER')
+              .commit()
+              .one();
+          });
+      });
+    })
+    .then((writtenCPVs) => {
+      console.log(`Upserted ${writtenCPVs.length} CPVs`);
+      process.exit();
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(-1);
+    });
+}
+
+importCPVs();

--- a/test/api/controllers/cpvs.js
+++ b/test/api/controllers/cpvs.js
@@ -3,10 +3,13 @@
 const _ = require('lodash');
 const request = require('supertest');
 const test = require('ava').test;
-const helpers = require('../../helpers');
+const writers = require('../../../api/writers');
 const codes = require('../../../api/helpers/codes');
+const config = require('../../../config/default');
+const cpvController = require('../../../api/controllers/cpvs');
+const helpers = require('../../helpers');
 const app = require('../../../server');
-const factory = require('../../factory');
+const fixtures = require('../../fixtures');
 
 test.before(() => helpers.createDB());
 test.afterEach.always(() => helpers.truncateDB());
@@ -16,18 +19,126 @@ test.serial('listCpvs returns empty array if there are no cpvs', async (t) => {
   const res = await request(app)
     .get('/cpvs');
   t.is(res.status, codes.SUCCESS);
-  t.deepEqual(res.body, { cpvs: [] });
+  t.deepEqual({ cpvs: [] }, res.body);
 });
 
 test.serial('listCpvs returns all cpvs by default', async (t) => {
   t.plan(2);
-  const cpvs = await factory.createMany('cpv', 2);
-  const expectedResponse = {
-    cpvs: _.map(cpvs, (cpv) => cpv.formatJSON()),
-  };
+  const cpvs = fixtures.assocAttrsMany('rawCpv', 2);
+  await fixtures.build('rawFullTender', { cpvs })
+    .then((rawTender) => writers.writeTender(rawTender));
+  const expectedResponse = await config.db.select().from('CPV').all()
+    .then((writtenCpvs) => ({
+      cpvs: _.map(writtenCpvs, (cpv) => cpvController.formatCpv(cpv)),
+    }));
   const res = await request(app)
     .get('/cpvs');
   t.is(res.status, codes.SUCCESS);
   t.deepEqual(expectedResponse, res.body);
 });
 
+test.serial('listCpvs filters cpvs by country', async (t) => {
+  t.plan(2);
+  const rawMatchTender = await fixtures.build('rawFullTender', {
+    cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+    country: 'RO',
+  }).then((ten) => writers.writeTender(ten));
+  await fixtures.build('rawFullTender', {
+    cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+    country: 'NL',
+  }).then((ten) => writers.writeTender(ten));
+  const expectedResponse = await config.db.select('expand(out("HasCPV"))')
+    .from('Tender')
+    .where({ id: rawMatchTender.id })
+    .all()
+    .then((writtenCpvs) => ({
+      cpvs: _.map(writtenCpvs, (cpv) => cpvController.formatCpv(cpv)),
+    }));
+  const res = await request(app)
+    .get('/cpvs?countries[]=RO');
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(expectedResponse, res.body);
+});
+
+test.serial('listCpvs filters cpvs by buyer', async (t) => {
+  t.plan(2);
+  const buyer = await fixtures.build('rawBuyer');
+  const rawMatchTender = await fixtures.build('rawFullTender', {
+    cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+    buyers: [buyer],
+  }).then((ten) => writers.writeTender(ten));
+  await fixtures.build('rawFullTender', {
+    cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+  }).then((ten) => writers.writeTender(ten));
+
+  const expectedResponse = await config.db.select('expand(out("HasCPV"))')
+    .from('Tender')
+    .where({ id: rawMatchTender.id })
+    .all()
+    .then((writtenCpvs) => ({
+      cpvs: _.map(writtenCpvs, (cpv) => cpvController.formatCpv(cpv)),
+    }));
+  const res = await request(app)
+    .get(`/cpvs?buyers[]=${buyer.id}`);
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(expectedResponse, res.body);
+});
+
+test.serial('listCpvs filters cpvs by bidder', async (t) => {
+  t.plan(2);
+  const bidder = await fixtures.build('rawBidder');
+  const rawMatchTender = await fixtures.build('rawBid', { bidders: [bidder] })
+    .then((bid) => fixtures.build('rawLot', { bids: [bid] }))
+    .then((lot) => fixtures.build('rawFullTender', {
+      cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+      lots: [lot],
+    }))
+    .then((ten) => writers.writeTender(ten));
+  await fixtures.build('rawFullTender', {
+    cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+  }).then((ten) => writers.writeTender(ten));
+
+  const expectedResponse = await config.db.select('expand(out("HasCPV"))')
+    .from('Tender')
+    .where({ id: rawMatchTender.id })
+    .all()
+    .then((writtenCpvs) => ({
+      cpvs: _.map(writtenCpvs, (cpv) => cpvController.formatCpv(cpv)),
+    }));
+  const res = await request(app)
+    .get(`/cpvs?bidders[]=${bidder.id}`);
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(expectedResponse, res.body);
+});
+
+test.serial('listCpvs filters cpvs by year', async (t) => {
+  t.plan(2);
+  const rawMatchTender = await fixtures.build('rawLotWithBid', {
+    awardDecisionDate: '2016-01-02',
+  })
+    .then((lot) => fixtures.build('rawFullTender', {
+      cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+      lots: [lot],
+    }))
+    .then((ten) => writers.writeTender(ten));
+  await fixtures.build('rawLot', {
+    awardDecisionDate: '2017-01-10',
+  })
+    .then((lot) => fixtures.build('rawFullTender', {
+      cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+      lots: [lot],
+    }))
+    .then((ten) => writers.writeTender(ten));
+
+  const expectedResponse = await config.db.select('expand(out("HasCPV"))')
+    .from('Tender')
+    .where({ id: rawMatchTender.id })
+    .all()
+    .then((writtenCpvs) => ({
+      cpvs: _.map(writtenCpvs, (cpv) => cpvController.formatCpv(cpv)),
+    }));
+  const res = await request(app)
+    .get('/cpvs?years[]=2016');
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(expectedResponse, res.body);
+});

--- a/test/api/controllers/cpvs.js
+++ b/test/api/controllers/cpvs.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const _ = require('lodash');
+const request = require('supertest');
+const test = require('ava').test;
+const helpers = require('../../helpers');
+const codes = require('../../../api/helpers/codes');
+const app = require('../../../server');
+const factory = require('../../factory');
+
+test.before(() => helpers.createDB());
+test.afterEach.always(() => helpers.truncateDB());
+
+test.serial('listCpvs returns empty array if there are no cpvs', async (t) => {
+  t.plan(2);
+  const res = await request(app)
+    .get('/cpvs');
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(res.body, { cpvs: [] });
+});
+
+test.serial('listCpvs returns all cpvs by default', async (t) => {
+  t.plan(2);
+  const cpvs = await factory.createMany('cpv', 2);
+  const expectedResponse = {
+    cpvs: _.map(cpvs, (cpv) => cpv.formatJSON()),
+  };
+  const res = await request(app)
+    .get('/cpvs');
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(expectedResponse, res.body);
+});
+

--- a/test/api/writers.js
+++ b/test/api/writers.js
@@ -138,7 +138,6 @@ test.serial('writeTender updates existing bids', async (t) => {
     .to(existingLot['@rid'])
     .commit()
     .one();
-
   const updatedBidAttrs = await fixtures.build('rawBid', { isWinning: true });
   const updatedLotAttrs = await fixtures.build('rawLot', { bids: [updatedBidAttrs] });
   const updatedTenderAttrs = await fixtures.build('rawTender', {
@@ -259,7 +258,7 @@ test.serial('createBid creates an edge between bid and buyers', async (t) => {
     tr.create('vertex', 'Buyer').set(rawBuyer));
   transaction.let(lotName, (tr) =>
     tr.create('vertex', 'Lot').set(rawLot));
-  const writtenBid = await writers.createBid(transaction, rawBid, lotName, [buyerName])
+  const writtenBid = await writers.createBid(transaction, rawBid, lotName, [buyerName], {}, {})
     .then((bidName) => transaction.commit()
       .return(`$${bidName}`)
       .one());

--- a/test/api/writers.js
+++ b/test/api/writers.js
@@ -249,6 +249,7 @@ test.serial('upsertBuyer updates the edge between existing buyer and existing te
 });
 
 test.serial('createBid creates an edge between bid and buyers', async (t) => {
+  const rawTender = await fixtures.create('rawTender');
   const rawBid = await fixtures.create('rawBid');
   const rawLot = await fixtures.create('extractedLot');
   const rawBuyer = await fixtures.create('extractedBuyer');
@@ -258,7 +259,7 @@ test.serial('createBid creates an edge between bid and buyers', async (t) => {
     tr.create('vertex', 'Buyer').set(rawBuyer));
   transaction.let(lotName, (tr) =>
     tr.create('vertex', 'Lot').set(rawLot));
-  const writtenBid = await writers.createBid(transaction, rawBid, lotName, [buyerName], {}, {})
+  const writtenBid = await writers.createBid(transaction, rawBid, lotName, [buyerName], rawTender, {}) // eslint-disable-line max-len
     .then((bidName) => transaction.commit()
       .return(`$${bidName}`)
       .one());

--- a/test/base_node.js
+++ b/test/base_node.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const _ = require('lodash');
+const config = require('../config/default');
+
+// Base node class for use in factories
+class BaseNode {
+  constructor(attrs = {}) {
+    Object.assign(this, attrs);
+    if (_.isUndefined(this.class)) {
+      throw Error('Attribute "class" is necessary to know what kind of node to create.');
+    }
+  }
+  async save() {
+    const created = await config.db.create('vertex', this.class)
+      .set(this).commit().one();
+    return created;
+  }
+  async destroy() {
+    const deleted = await config.db.delete('vertex', this.class)
+      .where({ id: this.id }).commit().one();
+    return deleted;
+  }
+  formatJSON() {
+    return JSON.parse(JSON.stringify(_.omit(this, ['class'])));
+  }
+}
+
+module.exports = BaseNode;

--- a/test/extractors/bid.js
+++ b/test/extractors/bid.js
@@ -8,16 +8,34 @@ const fixtures = require('./../fixtures');
 test('extractBid extracts contract award notice id from publications', async (t) => {
   const publication = await fixtures.build('rawContractAwardNotice');
   const rawBid = await fixtures.build('rawBid');
+  const rawTender = await fixtures.build('rawTender', {
+    publications: [publication],
+  });
   t.is(
-    bidExtractor.extractBid(rawBid, [publication]).xTEDCANID,
+    bidExtractor.extractBid(rawBid, rawTender, {}).xTEDCANID,
     publication.sourceId,
   );
 });
 
 test('extractBid returns null if there is no publication', async (t) => {
   const rawBid = await fixtures.build('rawBid');
+  const rawTender = await fixtures.build('rawTender', {
+    publications: [],
+  });
   t.is(
-    bidExtractor.extractBid(rawBid, []).xTEDCANID,
+    bidExtractor.extractBid(rawBid, rawTender, {}).xTEDCANID,
     undefined,
+  );
+});
+
+test('extractBid extracts year from lots award decision date', async (t) => {
+  const rawBid = await fixtures.build('rawBid');
+  const year = 2015;
+  const rawLot = await fixtures.build('rawLot', {
+    awardDecisionDate: `${year}-02-12`,
+  });
+  t.is(
+    bidExtractor.extractBid(rawBid, {}, rawLot).xYear,
+    year,
   );
 });

--- a/test/factory.js
+++ b/test/factory.js
@@ -13,12 +13,3 @@ factory.define('tender', BaseNode, {
   xDigiwhistLastModified: '2017-06-08 11:55:43',
   country: 'NL',
 });
-
-factory.define('cpv', BaseNode, {
-  class: 'CPV',
-  code: factory.sequence((n) => `0136648903${n}`),
-  xName: 'Butterbear',
-  xNumberDigits: factory.sequence((n) => n),
-});
-module.exports = factory;
-

--- a/test/factory.js
+++ b/test/factory.js
@@ -1,18 +1,24 @@
 'use strict';
 
+const uuidv4 = require('uuid/v4');
 const FactoryGirl = require('factory-girl');
-const Tender = require('../api/models/tender');
+const BaseNode = require('./base_node');
 
 const factory = FactoryGirl.factory;
 factory.setAdapter(new FactoryGirl.DefaultAdapter());
 
-factory.define('tender', Tender, {
-  // use sequences to generate values sequentially
-  id: factory.sequence((n) => `tender_${n}`),
+factory.define('tender', BaseNode, {
+  class: 'Tender',
+  id: uuidv4(),
   xDigiwhistLastModified: '2017-06-08 11:55:43',
   country: 'NL',
 });
 
-
+factory.define('cpv', BaseNode, {
+  class: 'CPV',
+  code: factory.sequence((n) => `0136648903${n}`),
+  xName: 'Butterbear',
+  xNumberDigits: factory.sequence((n) => n),
+});
 module.exports = factory;
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -28,8 +28,9 @@ factory.define('extractedTender', Object, tenderAttrs, {
 });
 
 const cpvAttrs = {
-  code: '12021220-1',
+  code: factory.sequence((n) => `12021220-${n}`),
   name: 'Talkative ghosts',
+  xNumberDigits: 3,
 };
 factory.define('rawCpv', Object, cpvAttrs);
 factory.define('extractedCpv', Object, cpvAttrs, {
@@ -79,7 +80,7 @@ factory.define('extractedBid', Object, bidAttrs, {
   afterBuild: async (rawBid) => {
     const rawTenderAttrs = await factory.build('rawTender');
     const rawLotAttrs = await factory.build('rawLot');
-    bidExtractor.extractBid(rawBid, rawTenderAttrs, rawLotAttrs);
+    return bidExtractor.extractBid(rawBid, rawTenderAttrs, rawLotAttrs);
   },
 });
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -76,7 +76,11 @@ const bidAttrs = {
 };
 factory.define('rawBid', Object, bidAttrs);
 factory.define('extractedBid', Object, bidAttrs, {
-  afterBuild: (rawBid) => bidExtractor.extractBid(rawBid),
+  afterBuild: async (rawBid) => {
+    const rawTenderAttrs = await factory.build('rawTender');
+    const rawLotAttrs = await factory.build('rawLot');
+    bidExtractor.extractBid(rawBid, rawTenderAttrs, rawLotAttrs);
+  },
 });
 
 const bidderAttrs = {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const FactoryGirl = require('factory-girl');
 const uuidv4 = require('uuid/v4');
+const FactoryGirl = require('factory-girl');
 const tenderExtractor = require('./../extractors/tender');
 const buyerExtractor = require('./../extractors/buyer');
 const lotExtractor = require('./../extractors/lot');


### PR DESCRIPTION
Meaning only 1 endpoint that:
- returns all cpvs by default
- returns cpvs filtered by `countries`, `years`, `bidders`, `buyers`
