### PR TITLE
Query builder endpoints for countries

### DIFF
--- a/api/controllers/countries.js
+++ b/api/controllers/countries.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const _ = require('lodash');
+const codes = require('../helpers/codes');
+const config = require('../../config/default');
+const formatError = require('../helpers/errorFormatter');
+
+function getTenderCountries(req, res) {
+  const swaggerParams = _.pickBy(
+    _.mapValues(req.swagger.params, 'value'),
+    (val) => !(_.isUndefined(val)),
+  );
+  const queryCriteria = ['{ class: Bid, as: bids }'];
+  const queryParams = {};
+  if (swaggerParams.cpvs) {
+    queryCriteria.push(`{ as: bids }.out('AppliedTo').in('Comprises').out('HasCPV')
+      { class: CPV, where: (code in :cpvs)}`);
+    queryParams.cpvs = swaggerParams.cpvs;
+  }
+  if (swaggerParams.years) {
+    queryCriteria.push('{ as: bids,  where: (xYear in :years) }');
+    queryParams.years = swaggerParams.years;
+  }
+  if (swaggerParams.buyers) {
+    queryCriteria.push(`{ as: bids }.in('Awards')
+      { class: Buyer, where: (id in :buyers) }`);
+    queryParams.buyers = swaggerParams.buyers;
+  }
+  if (swaggerParams.bidders) {
+    queryCriteria.push(`{ as: bids }.in('Participates')
+      { class: Bidder, where: (id in :bidders) }`);
+    queryParams.bidders = swaggerParams.bidders;
+  }
+  const query = `SELECT distinct(country) FROM (
+    MATCH ${_.join(queryCriteria, ',')}
+    RETURN bids.xCountry as country
+  )`;
+  return config.db.query(query, { params: queryParams })
+    .then((results) => config.db.query(
+      'SELECT * from Country where code in :countryCodes',
+      { params: { countryCodes: _.map(results, 'distinct') } },
+    ))
+    .then((results) => res.status(codes.SUCCESS).json({
+      countries: _.map(results, (country) => formatCountry(country)),
+    }))
+    .catch((err) => formatError(err, req, res));
+}
+
+function formatCountry(country) {
+  return _.pick(country, ['code', 'name']);
+}
+
+module.exports = {
+  getTenderCountries,
+  formatCountry,
+};

--- a/api/controllers/cpvs.js
+++ b/api/controllers/cpvs.js
@@ -5,44 +5,37 @@ const codes = require('../helpers/codes');
 const config = require('../../config/default');
 const formatError = require('../helpers/errorFormatter');
 
-function listCpvs(req, res) {
+function getTenderCpvs(req, res) {
   const swaggerParams = _.pickBy(
     _.mapValues(req.swagger.params, 'value'),
     (val) => !(_.isUndefined(val)),
   );
-  let cpvs;
-  if (_.isEmpty(swaggerParams)) {
-    cpvs = config.db.select().from('CPV').all();
-  } else {
-    const queryCriteria = [];
-    const queryParams = {};
-    if (swaggerParams.countries) {
-      queryCriteria.push('{ as: bids,  where: (xCountry in :countries) }');
-      queryParams.countries = swaggerParams.countries;
-    }
-    if (swaggerParams.years) {
-      queryCriteria.push('{ as: bids,  where: (xYear in :years) }');
-      queryParams.years = swaggerParams.years;
-    }
-    if (swaggerParams.buyers) {
-      queryCriteria.push(`{ as: bids }.in('Awards')
-        { class: Buyer, where: (id in :buyers) }`);
-      queryParams.buyers = swaggerParams.buyers;
-    }
-    if (swaggerParams.bidders) {
-      queryCriteria.push(`{ as: bids }.in('Participates')
-        { class: Bidder, where: (id in :bidders) }`);
-      queryParams.bidders = swaggerParams.bidders;
-    }
-    const query = `SELECT expand(cpvs) FROM (
-      MATCH { class: Bid, as: bids },
-        ${_.join(queryCriteria, ',')},
-        { as: bids }.out('AppliedTo').in('Comprises').out('HasCPV'){ as: cpvs }
-      RETURN cpvs
-    )`;
-    cpvs = config.db.query(query, { params: queryParams });
+  const queryCriteria = ["{ as: bids }.out('AppliedTo').in('Comprises').out('HasCPV'){ as: cpvs }"];
+  const queryParams = {};
+  if (swaggerParams.countries) {
+    queryCriteria.push('{ as: bids,  where: (xCountry in :countries) }');
+    queryParams.countries = swaggerParams.countries;
   }
-  return cpvs
+  if (swaggerParams.years) {
+    queryCriteria.push('{ as: bids,  where: (xYear in :years) }');
+    queryParams.years = swaggerParams.years;
+  }
+  if (swaggerParams.buyers) {
+    queryCriteria.push(`{ as: bids }.in('Awards')
+      { class: Buyer, where: (id in :buyers) }`);
+    queryParams.buyers = swaggerParams.buyers;
+  }
+  if (swaggerParams.bidders) {
+    queryCriteria.push(`{ as: bids }.in('Participates')
+      { class: Bidder, where: (id in :bidders) }`);
+    queryParams.bidders = swaggerParams.bidders;
+  }
+  const query = `SELECT expand(cpvs) FROM (
+    MATCH { class: Bid, as: bids },
+      ${_.join(queryCriteria, ',')}
+    RETURN cpvs
+  )`;
+  return config.db.query(query, { params: queryParams })
     .then((results) => res.status(codes.SUCCESS).json({
       cpvs: _.map(results, (cpv) => formatCpv(cpv)),
     }))
@@ -54,6 +47,6 @@ function formatCpv(cpvNode) {
 }
 
 module.exports = {
-  listCpvs,
+  getTenderCpvs,
   formatCpv,
 };

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -74,8 +74,59 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/CpvIndex"
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad request [Request validation failed (wrong param type)]
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /tenders/countries:
+    x-swagger-router-controller: countries
+    get:
+      tags:
+        - countries
+      description: Returns a list of all the countries for which we have tenders
+      operationId: getTenderCountries
+      parameters:
+        - name: cpvs
+          in: query
+          description: Get only the countries of tenders that have these CPVs - array of CPV codes
+          required: false
+          type: array
+          items:
+            type: string
+        - name: years
+          in: query
+          description: Get only the countries of tenders from certain years - array of years
+          required: false
+          type: array
+          items:
+            type: integer
+        - name: buyers
+          in: query
+          description: Get only the countries of tenders awarded by certain buyers - array of buyer IDs
+          required: false
+          type: array
+          items:
+            type: string
+            format: uuid
+        - name: bidders
+          in: query
+          description: Get only the countries of tenders awarded to certain bidders - array of bidder IDs
+          required: false
+          type: array
+          items:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/CountryIndex"
+        "400":
+          description: Bad request [Request validation failed (wrong param type)]
           schema:
             $ref: "#/definitions/ErrorResponse"
         default:
@@ -476,6 +527,22 @@ definitions:
       xNumberDigits:
         type: integer
         description: Number of relevant digits in the CPV
+  CountryIndex:
+    type: object
+    properties:
+      countries:
+        type: array
+        items:
+          $ref: "#/definitions/Country"
+  Country:
+    type: object
+    properties:
+      code:
+        type: string
+        description: ISO 3166-1 alpha-2 country code
+      name:
+        type: string
+        description: Full name of the country
   ErrorResponse:
     type: object
     required:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -31,31 +31,31 @@ paths:
   /swagger.yaml:
     x-swagger-pipe: swagger_raw
 
-  /cpvs:
+  /tenders/cpvs:
     x-swagger-router-controller: cpvs
     get:
       tags:
         - cpvs
-      description: Returns a list of all cpvs in the db
-      operationId: listCpvs
+      description: Returns a list of CPVs from all the tenders in the database
+      operationId: getTenderCpvs
       parameters:
         - name: countries
           in: query
-          description: Get only the CPVs of contracts from certain countries
+          description: Get only the CPVs of tenders from certain countries - array of ISO 3166-1 alpha-2 country codes
           required: false
           type: array
           items:
             type: string
         - name: years
           in: query
-          description: Get only the CPVs of contracts from certain countries
+          description: Get only the CPVs of tenders from certain years - array of years
           required: false
           type: array
           items:
             type: integer
         - name: buyers
           in: query
-          description: Get only the CPVs of contracts awarded by certain buyers
+          description: Get only the CPVs of tenders awarded by certain buyers - array of buyer IDs
           required: false
           type: array
           items:
@@ -63,7 +63,7 @@ paths:
             format: uuid
         - name: bidders
           in: query
-          description: Get only the CPVs of contracts awarded to certain bidders
+          description: Get only the CPVs of tenders awarded to certain bidders - array of bidder IDs
           required: false
           type: array
           items:

--- a/migrations/m20180107_083629_create_country_class.js
+++ b/migrations/m20180107_083629_create_country_class.js
@@ -1,0 +1,29 @@
+'use strict';
+
+exports.name = 'create country class';
+
+exports.up = (db) => (
+  db.class.create('Country')
+    .then((Country) => {
+      Country.property.create([
+        {
+          name: 'code',
+          type: 'String',
+          mandatory: true,
+        },
+        {
+          name: 'name',
+          type: 'String',
+          mandatory: true,
+        },
+      ]);
+    })
+    .then(() => {
+      db.index.create({
+        name: 'Country.code',
+        type: 'UNIQUE_HASH_INDEX',
+      });
+    })
+);
+
+exports.down = (db) => db.class.drop('Country');

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const https = require('https');
+const Promise = require('bluebird');
+
+const codes = require('../api/helpers/codes');
+
+function fetchRemoteFile(URL) {
+  return new Promise((resolve, reject) => {
+    https.get(URL, (res) => {
+      const { statusCode } = res;
+      if (statusCode !== codes.SUCCESS) {
+        throw new Error(`Request failed with status code: ${statusCode}`);
+      }
+
+      res.setEncoding('utf8');
+      let rawData = '';
+      res.on('data', (chunk) => { rawData += chunk; });
+      res.on('end', () => resolve(JSON.parse(rawData)));
+    }).on('error', (e) => {
+      reject(e);
+    });
+  });
+}
+
+module.exports = {
+  fetchRemoteFile,
+};

--- a/scripts/import_countries.js
+++ b/scripts/import_countries.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+const _ = require('lodash');
+const { URL } = require('url');
+const Promise = require('bluebird');
+
+const config = require('../config/default');
+const helpers = require('./helpers');
+
+const countriesURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/countrynames_iso2_correspondence.json');
+
+function importCountries() {
+  helpers.fetchRemoteFile(countriesURL)
+    .then((countriesMapping) => {
+      console.log('Upserting countries...');
+      return Promise.all(_.values(_.mapValues(countriesMapping, (name, code) =>
+        config.db.select().from('Country')
+          .where({ code })
+          .one()
+          .then((existingCountry) => {
+            if (_.isUndefined(existingCountry)) {
+              return config.db.class.get('Country')
+                .then((Country) => Country.create({
+                  code,
+                  name,
+                }));
+            }
+            return config.db.update(existingCountry['@rid'])
+              .set({
+                code,
+                name,
+              })
+              .one();
+          }))));
+    })
+    .then((writtenCountries) => {
+      console.log(`Upserted ${writtenCountries.length} countries`);
+      process.exit();
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(-1);
+    });
+}
+
+importCountries();

--- a/scripts/import_cpvs.js
+++ b/scripts/import_cpvs.js
@@ -4,35 +4,15 @@
 
 const _ = require('lodash');
 const { URL } = require('url');
-const https = require('https');
 const Promise = require('bluebird');
 
 const config = require('../config/default');
-const codes = require('../api/helpers/codes');
+const helpers = require('./helpers');
 
 const cpvsURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpv_codes.json');
 
-function fetchCPVs() {
-  return new Promise((resolve, reject) => {
-    console.log('Fetching CPVs...');
-    https.get(cpvsURL, (res) => {
-      const { statusCode } = res;
-      if (statusCode !== codes.SUCCESS) {
-        throw new Error(`Request failed with status code: ${statusCode}`);
-      }
-
-      res.setEncoding('utf8');
-      let rawData = '';
-      res.on('data', (chunk) => { rawData += chunk; });
-      res.on('end', () => resolve(JSON.parse(rawData)));
-    }).on('error', (e) => {
-      reject(e);
-    });
-  });
-}
-
 function importCPVs() {
-  fetchCPVs()
+  helpers.fetchRemoteFile(cpvsURL)
     .then((cpvList) => {
       console.log('Upserting CPVs...');
       return Promise.map(cpvList, (rawCpv) => {

--- a/scripts/import_data.js
+++ b/scripts/import_data.js
@@ -59,6 +59,6 @@ function importFileData(filePath, concurrency, retries) {
   });
 }
 
-module.export = {
+module.exports = {
   importFileData,
 };

--- a/test/api/controllers/countries.js
+++ b/test/api/controllers/countries.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const _ = require('lodash');
+const request = require('supertest');
+const test = require('ava').test;
+const writers = require('../../../api/writers');
+const codes = require('../../../api/helpers/codes');
+const config = require('../../../config/default');
+const controller = require('../../../api/controllers/countries');
+const helpers = require('../../helpers');
+const app = require('../../../server');
+const fixtures = require('../../fixtures');
+
+test.before(() => helpers.createDB());
+test.afterEach.always(() => helpers.truncateDB());
+
+function expectedResponse(countryCode) {
+  return config.db.select()
+    .from('Country')
+    .where({ code: countryCode })
+    .all()
+    .then((countries) => ({
+      countries: _.map(countries, (country) => controller.formatCountry(country)),
+    }));
+}
+test.serial('getTenderCountries returns empty array if there are no bids', async (t) => {
+  t.plan(2);
+  const res = await request(app)
+    .get('/tenders/countries');
+
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual({ countries: [] }, res.body);
+});
+
+test.serial('getTenderCountries returns all cpvs by default', async (t) => {
+  t.plan(2);
+  const expectedCountry = 'CZ';
+  await fixtures.build('rawFullTender', { country: expectedCountry })
+    .then((rawTender) => writers.writeTender(rawTender));
+  const res = await request(app)
+    .get('/tenders/countries');
+
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(await expectedResponse(expectedCountry), res.body);
+});
+
+test.serial('getTenderCountries filters countries by cpvs', async (t) => {
+  t.plan(2);
+  const cpv = await fixtures.build('rawCpv');
+  const expectedCountry = 'CZ';
+  const alternativeCountry = 'NL';
+  await fixtures.build('rawFullTender', {
+    cpvs: [cpv],
+    country: expectedCountry,
+  }).then((ten) => writers.writeTender(ten));
+  await fixtures.build('rawFullTender', {
+    cpvs: fixtures.assocAttrsMany('rawCpv', 2),
+    country: alternativeCountry,
+  }).then((ten) => writers.writeTender(ten));
+  const res = await request(app)
+    .get(`/tenders/countries?cpvs=${cpv.code}`);
+
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(await expectedResponse(expectedCountry), res.body);
+});
+
+test.serial('getTenderCountries filters countries by buyer', async (t) => {
+  t.plan(2);
+  const expectedCountry = 'CZ';
+  const alternativeCountry = 'NL';
+  const buyer = await fixtures.build('rawBuyer');
+  await fixtures.build('rawFullTender', {
+    buyers: [buyer],
+    country: expectedCountry,
+  }).then((ten) => writers.writeTender(ten));
+  await fixtures.build('rawFullTender', {
+    country: alternativeCountry,
+  }).then((ten) => writers.writeTender(ten));
+  const res = await request(app)
+    .get(`/tenders/countries?buyers[]=${buyer.id}`);
+
+  t.is(res.status, codes.SUCCESS);
+  await t.deepEqual(await expectedResponse(expectedCountry), res.body);
+});
+
+test.serial('getTenderCountries filters countries by bidder', async (t) => {
+  t.plan(2);
+  const expectedCountry = 'CZ';
+  const alternativeCountry = 'NL';
+  const bidder = await fixtures.build('rawBidder');
+  await fixtures.build('rawBid', { bidders: [bidder] })
+    .then((bid) => fixtures.build('rawLot', { bids: [bid] }))
+    .then((lot) => fixtures.build('rawFullTender', {
+      lots: [lot],
+      country: expectedCountry,
+    }))
+    .then((ten) => writers.writeTender(ten));
+  await fixtures.build('rawFullTender', {
+    country: alternativeCountry,
+  }).then((ten) => writers.writeTender(ten));
+  const res = await request(app)
+    .get(`/tenders/countries?bidders[]=${bidder.id}`);
+
+  t.is(res.status, codes.SUCCESS);
+  await t.deepEqual(await expectedResponse(expectedCountry), res.body);
+});
+
+test.serial('getTenderCountries filters countries by year', async (t) => {
+  t.plan(2);
+  const expectedCountry = 'CZ';
+  const alternativeCountry = 'NL';
+  await fixtures.build('rawLotWithBid', {
+    awardDecisionDate: '2016-01-02',
+  })
+    .then((lot) => fixtures.build('rawFullTender', {
+      lots: [lot],
+      country: expectedCountry,
+    }))
+    .then((ten) => writers.writeTender(ten));
+  await fixtures.build('rawLot', {
+    awardDecisionDate: '2017-01-10',
+  })
+    .then((lot) => fixtures.build('rawFullTender', {
+      lots: [lot],
+      country: alternativeCountry,
+    }))
+    .then((ten) => writers.writeTender(ten));
+  const res = await request(app)
+    .get('/tenders/countries?years[]=2016');
+
+  t.is(res.status, codes.SUCCESS);
+  await t.deepEqual(await expectedResponse(expectedCountry), res.body);
+});


### PR DESCRIPTION
Get countries from which we have tenders + ability to filter the tenders from which we aggregate by cpvs, bidders, buyers and years.

I also changed the cpvs endpoint to return by default only the cpvs for which we have tenders, not all cpvs.
  