### PR TITLE
[WIP] Refactor docker-compose config for production and dev use

### DIFF
--- a/deploy
+++ b/deploy
@@ -7,7 +7,7 @@ case "$ENV" in
         docker-compose -f docker-compose.yml -f docker-compose.prod.yml -p elvis-backend-prod up -d
         ;;
     "development")
-        docker-compose -f docker-compose.yml -f docker-compose.prod.yml -p elvis-backend-dev up -d
+        docker-compose -p elvis-backend-dev up -d
         ;;
     *)
         echo 'Use `deploy production` or `deploy development`'

--- a/deploy
+++ b/deploy
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+ENV=$1
+
+case "$ENV" in
+    "production")
+        docker-compose -f docker-compose.yml -f docker-compose.prod.yml -p elvis-backend-prod up -d
+        ;;
+    "development")
+        docker-compose -f docker-compose.yml -f docker-compose.prod.yml -p elvis-backend-dev up -d
+        ;;
+    *)
+        echo 'Use `deploy production` or `deploy development`'
+        ;;
+esac

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  elvis_api:
+    ports:
+      - "10010:10010"
+  orientdb:
+    ports:
+      - 2424:2424
+      - 2480:2480
+    environment:
+      - ORIENTDB_ROOT_PASSWORD=$ORIENTDB_ROOT_PASSWORD
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  elvis_api:
+    ports:
+      - "10011:10010"
+  orientdb:
+    ports:
+      - 2425:2424
+      - 2481:2480
+    volumes:
+      - odb_data:/orientdb/databases
+      - odb_backup:/orientdb/backup
+volumes:
+  odb_data:
+  odb_backup:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3'
 services:
   elvis_api:
     build: .
-    ports:
-      - "10010:10010"
     env_file: .env
     restart: always
     links:
@@ -18,15 +16,5 @@ services:
   orientdb:
     image: orientdb:2.2.30
     restart: always
-    ports:
-      - 2424:2424
-      - 2480:2480
-    volumes:
-      - odb_data:/orientdb/databases
-      - odb_backup:/orientdb/backup
     environment:
       - ORIENTDB_ROOT_PASSWORD=$ORIENTDB_ROOT_PASSWORD
-volumes:
-  odb_data:
-  odb_backup:
-


### PR DESCRIPTION
For development work, nothing is changed (override is loaded automatically):

```
$ docker-compose up -d
```

For production deployment, use:

```
$ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
```


Exposed ports are different on production use, to allow running both envs in parallel (it's a cute hack to avoid creating dev/staging/prod and only have a dev/prod split env):

| environment | service | container port | exposed port | config file |
|-------|------|------|-----|----|
| production | elvis_api | 10010 | 10011 | docker-compose.prod.yml | 
| production | orientdb | 2424 | 2425 | docker-compose.prod.yml |
| production | orientdb | 2480 | 2481 | docker-compose.prod.yml |
| development | elvis_api | 10010 | 10010 | docker-compose.override.yml |
| development | orientdb | 2424 | 2424 | docker-compose.override.yml |
| development | orientdb | 2480 | 2480 | docker-compose.override.yml |
