### PR TITLE
Manually defined CORS fitting for bagpipes

### DIFF
--- a/api/fittings/cors.js
+++ b/api/fittings/cors.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function create() {
+  return (context, next) => {
+    const req = context.request;
+    const res = context.response;
+
+    const origin = req.headers.origin || '*';
+    res.header('Access-Control-Allow-Origin', origin);
+    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS,PATCH');
+    res.header('Access-Control-Allow-Headers', 'Origin,X-Requested-With,Content-type,Accept,X-Refresh-Token,Authorization');
+    res.header('Access-Control-Allow-Credentials', true);
+
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+
+    return next();
+  };
+};

--- a/server.js
+++ b/server.js
@@ -79,19 +79,7 @@ require('./passport').configureStrategies();
 app.use(bodyParser.urlencoded({ extended: true, limit: '200mb' }));
 app.use(bodyParser.json({ limit: '200mb' }));
 app.use(logger('dev'));
-app.all('/*', (req, res, next) => {
-  // cors
-  res.header('Access-Control-Allow-Origin', '*'); // TODO restrict to specified domain if necessary
-  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS,PATCH');
-  res.header('Access-Control-Allow-Headers', 'Origin,X-Requested-With,Content-type,Accept,X-Refresh-Token,Authorization');
-  res.header('Access-Control-Allow-Credentials', true);
 
-  if (req.method === 'OPTIONS') {
-    return res.status(200).end();
-  }
-
-  return next();
-});
 app.use(session({
   secret: config.session.secret,
   resave: false,


### PR DESCRIPTION
So, this was an adventure. Will make some notes for the future.

First, the `cors` module indirectly supplied by one of swagger's indirect dependency is no good here. Whatever you define in the configuration, will be partially overwritten by some magic internal libraries. Time to dig in, but before that I'll leave the configuration I tried here:

```js
  cors: {
    credentials: true,
    origin: [
      'https://tenders.exposed',
      'http://develop.tenders.exposed',
      'https://elvis-ember-develop.herokuapp.com',
      'https://elvis-ember-new-backend.herokuapp.com',
    ],
    // origin: true,  // We can use this if we want to automatically reflect request's origin
    methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'PATCH'],
    allowedHeaders: [ 'Origin', 'X-Requested-With', 'Content-type', 'Accept', 'X-Refresh-Token', 'Authorization'],
    optionsSuccessStatus: 200,
    preflightContinue: true,
  },
```

Second, I tried to use the [`swagger-express-middleware`](https://github.com/BigstickCarpet/swagger-express-middleware) library to inject a custom made middleware into swagger's own pipeline. This failed miserably, mostly because of the way we are creating the Swagger instance in `server.js` and my inability to refactor that by this library's taste.

Third, I had to `grep` around for whoever sets the `Access-Control-Allow-Origin` header. Found a promising match inside a default "fitting" of the `bagpipes` library. This seems to escalate the pipeline concept and bring it into Swagger by using some specifically tailored concepts, such as "pipes" and "fittings". After looking into it, I found a debug flag I could use to inspect the fittings and pipes flow, where I realised the following:

```
  pipes create fitting {"name":"cors"} +0ms
  pipes:fittings no user fitting cors in /home/victor/Workbench/elvis/elvis-backend-node/api/fittings +0ms
  pipes:fittings cors config: {"name":"cors"} +15ms
  pipes:fittings loaded user fitting cors from /home/victor/Workbench/elvis/elvis-backend-node/node_modules/swagger-node-runner/fittings +5ms
```

This part was by far the easiest, I created a fitting named "cors" in the designated location and moved the logic from `server.js` into it, with some sugar on top. Now we have control over CORS headers, however we want, since `bagpipes` won't interfere with our custom CORS fitting.

In a nutshell, quite a crazy puzzle for applying some goddamn headers.