### PR TITLE
Add id to Bid and Lot

### DIFF
--- a/api/controllers/cpvs.js
+++ b/api/controllers/cpvs.js
@@ -36,9 +36,9 @@ function getTenderCpvs(req, res) {
   const cpvsQuery = `SELECT cpv.code as code,
     cpv.xNumberDigits as xNumberDigits,
     cpv.xName as xName,
-    set(bidID).size() as xNumberBids
+    set(id).size() as xNumberBids
     FROM (
-      SELECT @rid as bidID, out('AppliedTo').in('Comprises').out('HasCPV') as cpv
+      SELECT id, out('AppliedTo').in('Comprises').out('HasCPV') as cpv
         FROM Bid
         ${queryCriteria.length ? ` WHERE ${_.join(queryCriteria, ' AND ')}` : ''}
       UNWIND cpv

--- a/api/controllers/network_actors.js
+++ b/api/controllers/network_actors.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const Promise = require('bluebird');
 const config = require('../../config/default');
 const clusterWriters = require('../writers/actor_cluster');
@@ -16,8 +17,12 @@ function getNetworkActor(req, res) {
       .from('NetworkActor')
       .where({ id: nodeID })
       .one(),
-    (network, networkActor) =>
-      networkActorSerializer.formatActorWithDetails(network, networkActor),
+    (network, networkActor) => {
+      if (_.isUndefined(networkActor) === true) {
+        throw codes.NotFound('Network actor not found.');
+      }
+      return networkActorSerializer.formatActorWithDetails(network, networkActor);
+    },
   )
     .then((networkActor) => res.status(codes.SUCCESS).json({
       node: networkActor,

--- a/api/controllers/network_edges.js
+++ b/api/controllers/network_edges.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const Promise = require('bluebird');
 
 const config = require('../../config/default');
@@ -21,6 +22,9 @@ function getNetworkEdge(req, res) {
       .where({ uuid: edgeUUID })
       .one(),
     (network, networkEdge) => {
+      if (_.isUndefined(networkEdge) === true) {
+        throw codes.NotFound('Network edge not found.');
+      }
       if (networkEdge.type === 'partners') {
         throw codes.NotImplemented('No details available for an edge of type "partners".');
       }

--- a/api/controllers/networks.js
+++ b/api/controllers/networks.js
@@ -65,7 +65,7 @@ function updateNetwork(req, res) {
           networkParams.updated = moment().format('YYYY-MM-DD HH:mm:ss');
           return config.db.update('Network')
             .set(networkParams)
-            .where({ '@rid': network['@rid'] })
+            .where({ id: network.id })
             .return('AFTER')
             .commit()
             .one();

--- a/api/serializers/bid.js
+++ b/api/serializers/bid.js
@@ -25,7 +25,7 @@ bidSerializer.formatBidWithBidders = function (network, bid) {
   const formattedBid = bidSerializer.formatBid(bid);
   return config.db.select("expand(in('Participates'))")
     .from('Bid')
-    .where({ '@rid': bid['@rid'] })
+    .where({ id: bid.id })
     .all()
     .then((bidders) => Promise.map(bidders, (bidder) =>
       actorSerializer.formatActorWithNode(network, bidder)))
@@ -38,7 +38,7 @@ bidSerializer.formatBidWithBidders = function (network, bid) {
 bidSerializer.formatBidWithRelated = function (network, bid) {
   const retrieveFormattedLot = config.db.select("expand(out('AppliedTo'))")
     .from('Bid')
-    .where({ '@rid': bid['@rid'] })
+    .where({ id: bid.id })
     .one()
     .then((lot) => lotSerializer.formatLotWithTender(network, lot));
   return Promise.join(

--- a/api/serializers/lot.js
+++ b/api/serializers/lot.js
@@ -30,7 +30,7 @@ lotSerializer.formatLotWithTender = function (network, lot) {
   const formattedLot = lotSerializer.formatLot(lot);
   return config.db.select("expand(in('Comprises'))")
     .from('Lot')
-    .where({ '@rid': lot['@rid'] })
+    .where({ id: lot.id })
     .one()
     .then((tender) =>
       tenderSerializer.formatTenderWithBuyers(network, tender))
@@ -44,7 +44,7 @@ lotSerializer.formatLotWithBids = function (network, lot) {
   const formattedLot = lotSerializer.formatLot(lot);
   return config.db.select("expand(in('AppliedTo'))")
     .from('Lot')
-    .where({ '@rid': lot['@rid'] })
+    .where({ id: lot.id })
     .all()
     .then((bids) => Promise.map(bids, (bid) =>
       bidSerializer.formatBidWithBidders(network, bid)))

--- a/api/serializers/network_edge.js
+++ b/api/serializers/network_edge.js
@@ -26,12 +26,12 @@ function formatContractsEdgeWithDetails(network, networkEdge) {
     { params: { edgeUUID: networkEdge.uuid } },
   )
     .then((result) => {
-      const detailsQuery = `SELECT set(@rid).size() as numberOfWinningBids,
+      const detailsQuery = `SELECT set(id).size() as numberOfWinningBids,
       sum(price.netAmountEur) as amountOfMoneyExchanged,
       list(price.netAmountEur).size() as numberOfAvailablePrices,
-      set(@rid) as bidRIDs
+      set(id) as bidIDs
         FROM (
-          SELECT *
+          SELECT id, price
           FROM Bid
           WHERE ${_.join(networkWriters.queryToBidFilters(network.query), ' AND ')}
           AND in('Awards').id in :edgeBuyerIDs
@@ -53,10 +53,10 @@ function formatContractsEdgeWithDetails(network, networkEdge) {
       edge.percentValuesMissing = 100 - (
         (_.get(details, 'numberOfAvailablePrices', 0) * 100) / details.numberOfWinningBids
       );
-      return Promise.map(details.bidRIDs, (bidRID) =>
+      return Promise.map(details.bidIDs, (bidID) =>
         config.db.select()
           .from('Bid')
-          .where({ '@rid': bidRID })
+          .where({ id: bidID })
           .one()
           .then((bid) => bidSerializer.formatBidWithRelated(network, bid)));
     })

--- a/api/writers/actor_cluster.js
+++ b/api/writers/actor_cluster.js
@@ -188,13 +188,13 @@ function createPartnersEdges(transaction, edgeToBidClass, network, actorIDs, clu
     sum(bidsCount) as value
     FROM (
       SELECT difference(pairIDs, :actorIDs) as outsider,
-      set(bidRID).size() as bidsCount
+      set(bidID).size() as bidsCount
       FROM (
-        SELECT bidRID,
+        SELECT bidID,
         set(actor.id, partner.id) as pairIDs,
         set(actor, partner) as pairRIDs
         FROM (
-          SELECT @rid as bidRID,
+          SELECT id as bidID,
           in('${edgeToBidClass}') as actor,
           in('${edgeToBidClass}') as partner
           FROM Bid
@@ -237,7 +237,7 @@ function createContractsEdges(transaction, edgeToBidClass, network, actorIDs, cl
   const clusterContractsQuery = `SELECT contractor.id as contractorID,
     ${valueQuery} as value
     FROM (
-      SELECT @rid as bidRID,
+      SELECT id,
       in('${contractorEdge}') as contractor,
       in('${edgeToBidClass}') as clusterActor
       FROM Bid
@@ -294,7 +294,7 @@ function retrieveNetworkActor(actorID, networkID) {
         return config.db.select("expand(in('Includes'))")
           .from('NetworkActor')
           .where({
-            '@rid': networkActor['@rid'],
+            id: networkActor.id,
           })
           .one();
       }

--- a/api/writers/network.js
+++ b/api/writers/network.js
@@ -88,7 +88,7 @@ function createOwnsEdge(transaction, user, networkName) {
 function settingsToValueQuery(sizeSetting) {
   let value;
   if (sizeSetting === 'numberOfWinningBids') {
-    value = 'set(@rid).size()';
+    value = 'set(id).size()';
   } else if (sizeSetting === 'amountOfMoneyExchanged') {
     value = 'sum(price.netAmountEur)';
   }

--- a/api/writers/tender.js
+++ b/api/writers/tender.js
@@ -50,9 +50,9 @@ async function writeTender(fullTenderRecord) {
   if (_.isUndefined(existingTender) === false) {
     const existingLotRel = await config.db.select("out('Comprises')").from('Tender')
       .where({ '@rid': existingTenderID }).one();
-    const existingLotIDs = existingLotRel.out;
-    await Promise.map(existingLotIDs, (existingLotID) =>
-      deleteLot(transaction, existingLotID));
+    const existingLotRIDs = existingLotRel.out;
+    await Promise.map(existingLotRIDs, (existingLotRID) =>
+      deleteLot(transaction, existingLotRID));
   }
 
   await Promise.map((fullTenderRecord.lots || []), (rawLot) => {
@@ -66,27 +66,27 @@ async function writeTender(fullTenderRecord) {
   return transaction.commit(2).return(`$${tenderName}`).one();
 }
 
-async function deleteLot(transaction, lotID) {
+async function deleteLot(transaction, lotRID) {
   const lotName = `delete${recordName(uuidv4(), 'Lot')}`;
 
   transaction.let(lotName, (t) =>
     t.delete('vertex', 'Lot')
-      .where({ '@rid': lotID }));
+      .where({ '@rid': lotRID }));
 
   const existingBidRel = await config.db.select("in('AppliedTo')").from('Lot')
-    .where({ '@rid': lotID }).one();
-  const existingBidIDs = existingBidRel.in;
-  await Promise.map(existingBidIDs, (existingBidID) =>
-    deleteBid(transaction, existingBidID));
+    .where({ '@rid': lotRID }).one();
+  const existingBidRIDs = existingBidRel.in;
+  await Promise.map(existingBidRIDs, (existingBidRID) =>
+    deleteBid(transaction, existingBidRID));
   return lotName;
 }
 
-async function deleteBid(transaction, bidID) {
+async function deleteBid(transaction, bidRID) {
   const bidName = `delete${recordName(uuidv4(), 'Bid')}`;
 
   transaction.let(bidName, (t) =>
     t.delete('vertex', 'Bid')
-      .where({ '@rid': bidID }));
+      .where({ '@rid': bidRID }));
   return bidName;
 }
 

--- a/extractors/bid.js
+++ b/extractors/bid.js
@@ -2,10 +2,15 @@
 
 const _ = require('lodash');
 const moment = require('moment');
+const uuidv4 = require('uuid/v4');
 const priceExtractor = require('./price');
 
 function extractBid(bidAttrs, tenderAttrs, lotAttrs) {
+  if (_.isUndefined(bidAttrs.id) === false) {
+    console.log('Bid with id found', bidAttrs); // eslint-disable-line no-console
+  }
   return {
+    id: uuidv4(),
     isWinning: bidAttrs.isWinning,
     isSubcontracted: bidAttrs.isSubcontracted,
     isConsortium: bidAttrs.isConsortium,

--- a/extractors/bidder.js
+++ b/extractors/bidder.js
@@ -12,7 +12,6 @@ function extractBidder(bidderAttrs, tenderAttrs = {}) {
     normalizedName: helpers.removeDiacritics(bidderAttrs.name),
     address: bidderAttrs.address,
     isPublic: bidderAttrs.isPublic,
-    xDigiwhistLastModified: helpers.formatTimestamp(bidderAttrs.modified),
     indicators: _
       .filter((tenderAttrs.indicators || []), { relatedEntityId: bidderAttrs.id })
       .map((indicatorAttrs) => indicatorExtractor.extractIndicator(indicatorAttrs)),

--- a/extractors/buyer.js
+++ b/extractors/buyer.js
@@ -13,7 +13,6 @@ function extractBuyer(buyerAttrs, tenderAttrs = {}) {
     isPublic: buyerAttrs.isPublic,
     buyerType: buyerAttrs.buyerType,
     isSubsidized: buyerAttrs.isSubsidized,
-    xDigiwhistLastModified: helpers.formatTimestamp(buyerAttrs.modified),
     indicators: _
       .filter((tenderAttrs.indicators || []), { relatedEntityId: buyerAttrs.id })
       .map((indicatorAttrs) => indicatorExtractor.extractIndicator(indicatorAttrs)),

--- a/extractors/indicator.js
+++ b/extractors/indicator.js
@@ -9,7 +9,6 @@ function extractIndicator(indicatorAttrs) {
   }
   return {
     id: indicatorAttrs.id,
-    xDigiwhistLastModified: helpers.formatTimestamp(indicatorAttrs.modified),
     type: indicatorAttrs.type,
     value: indicatorAttrs.value,
   };

--- a/extractors/indicator.js
+++ b/extractors/indicator.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const helpers = require('./helpers');
 
 function extractIndicator(indicatorAttrs) {
   if (_.isUndefined(indicatorAttrs) || _.isEmpty(indicatorAttrs)) {

--- a/extractors/lot.js
+++ b/extractors/lot.js
@@ -1,9 +1,15 @@
 'use strict';
 
+const _ = require('lodash');
+const uuidv4 = require('uuid/v4');
 const priceExtractor = require('./price');
 
 function extractLot(lotAttrs) {
+  if (_.isUndefined(lotAttrs.id) === false) {
+    console.log('Bid with id found', lotAttrs); // eslint-disable-line no-console
+  }
   return {
+    id: uuidv4(),
     title: lotAttrs.title,
     description: lotAttrs.description,
     contractNumber: lotAttrs.contractNumber,

--- a/migrations/m20180315_083556_remove_mandatory_constraint_on_user_email.js
+++ b/migrations/m20180315_083556_remove_mandatory_constraint_on_user_email.js
@@ -18,4 +18,3 @@ exports.down = (db) => (
         type: 'String',
         mandatory: true,
       })));
-

--- a/migrations/m20180317_094849_remove_xDigiwhistLastModified.js
+++ b/migrations/m20180317_094849_remove_xDigiwhistLastModified.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Promise = require('bluebird');
+
+exports.name = 'remove xDigiwhistLastModified';
+
+exports.up = (db) => (
+  Promise.map(['Bidder', 'Buyer', 'Indicator'], (className) =>
+    db.class.get(className)
+      .then((Class) => Class.property.drop('xDigiwhistLastModified')))
+);
+
+exports.down = (db) => (
+  Promise.map(['Bidder', 'Buyer', 'Indicator'], (className) =>
+    db.class.get(className)
+      .then((Class) =>
+        Class.property.create([
+          {
+            name: 'xDigiwhistLastModified',
+            type: 'DateTime',
+            mandatory: true,
+          }])))
+);

--- a/migrations/m20180317_114503_add_id_to_bid.js
+++ b/migrations/m20180317_114503_add_id_to_bid.js
@@ -1,0 +1,26 @@
+'use strict';
+
+exports.name = 'add id to bid';
+
+exports.up = (db) => (
+  db.class.get('Bid')
+    .then((Bid) =>
+      Bid.property.create([
+        {
+          name: 'id',
+          type: 'String',
+          mandatory: true,
+        },
+      ]))
+    .then(() =>
+      db.index.create({
+        name: 'Bid.id',
+        type: 'UNIQUE_HASH_INDEX',
+      }))
+);
+
+exports.down = (db) => (
+  db.index.drop('Bid.id')
+    .then(() => db.class.get('Bid'))
+    .then((Bid) => Bid.property.drop('id'))
+);

--- a/migrations/m20180317_115138_add_id_to_lot.js
+++ b/migrations/m20180317_115138_add_id_to_lot.js
@@ -1,0 +1,26 @@
+'use strict';
+
+exports.name = 'add id to lot';
+
+exports.up = (db) => (
+  db.class.get('Lot')
+    .then((Lot) =>
+      Lot.property.create([
+        {
+          name: 'id',
+          type: 'String',
+          mandatory: true,
+        },
+      ]))
+    .then(() =>
+      db.index.create({
+        name: 'Lot.id',
+        type: 'UNIQUE_HASH_INDEX',
+      }))
+);
+
+exports.down = (db) => (
+  db.index.drop('Lot.id')
+    .then(() => db.class.get('Lot'))
+    .then((Lot) => Lot.property.drop('id'))
+);

--- a/migrations/m20180317_191612_add_unique_index_for_network_edge.js
+++ b/migrations/m20180317_191612_add_unique_index_for_network_edge.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.name = 'add unique index for network edge';
+
+exports.up = (db) => (
+  db.index.create({
+    name: 'NetworkEdge.uuid',
+    type: 'UNIQUE_HASH_INDEX',
+  })
+);
+
+exports.down = (db) => db.index.drop('NetworkEdge.uuid');

--- a/passport/index.js
+++ b/passport/index.js
@@ -17,7 +17,7 @@ module.exports.localStrategyCallback = (email, password, done) => {
     .one()
     .then((user) => {
       if (!user) {
-        return done(codes.BadRequest('Incorrect email.'), false);
+        return done(codes.BadRequest('No user with this email was found.'), false);
       }
       if (user.active === false) {
         return done(codes.BadRequest('Activate your account via email before logging in'), false);

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ const swaggerConfig = {
     twitterOauth: (req, def, scopes, callback) => {
       passport.authenticate('twitter', (err, user) => {
         if (err) {
-          console.log(err);
+          console.log(err); // eslint-disable-line no-console
           return callback(new Error('Error in passport authenticate'));
         }
 
@@ -36,7 +36,7 @@ const swaggerConfig = {
     githubOauth: (req, def, scopes, callback) => {
       passport.authenticate('github', (err, user) => {
         if (err) {
-          console.log(err);
+          console.log(err); // eslint-disable-line no-console
           return callback(new Error('Error in passport authenticate'));
         }
 

--- a/test/api/controllers/accounts.js
+++ b/test/api/controllers/accounts.js
@@ -138,8 +138,8 @@ test.serial('login: Wrong email', async (t) => {
     .send({ email: 'wrong_email@gmail.com', password: 'wrong_password' });
 
   t.is(res.status, codes.BAD_REQUEST);
-  t.regex(res.body.errors[0].message, /incorrect/i);
-  t.regex(res.body.errors[0].message, /email/i);
+  t.regex(res.body.errors[0].message, /user/i);
+  t.regex(res.body.errors[0].message, /found/i);
 });
 
 test.serial('login: Wrong password', async (t) => {


### PR DESCRIPTION
As I explained [in #82](https://github.com/tenders-exposed/elvis-backend-node/issues/82#issuecomment-373661339) the mere fetching by `@rid` is slow if no index is used.
So I added a unique UUID to `Bid` and `Lot` called `id` that we only use internally to make queries, especially compound ones,  more efficient.

Since we use this made up `id` and can't uniquely identify `Bid` and `Lot` from other fields (#67), we have to delete and recreate the bids and lots when we reimport the data so this `id` is not persistent and can't be used for endpoints. 