### PR TITLE
Adjust password reset payload

### DIFF
--- a/api/controllers/accounts.js
+++ b/api/controllers/accounts.js
@@ -210,26 +210,23 @@ function forgotPassword(req, res) {
 
 function resetPassword(req, res) {
   const requestObject = req.swagger.params.body.value;
+  let email;
   return AuthHelper.verifyToken(requestObject.resetPasswordToken)
     .then((decoded) => {
       if (!decoded.email) {
         throw codes.BadRequest('Wrong token.');
-      }
-      if (requestObject.email !== decoded.email) {
-        throw codes.BadRequest('Wrong token');
+      } else {
+        email = decoded.email;
       }
       return config.db.select('@rid').from('User')
         .where({
-          email: requestObject.email,
+          email,
         })
         .one();
     })
     .then((user) => {
       if (!user) {
         throw codes.NotFound('User not found.');
-      }
-      if (requestObject.password !== requestObject.passwordConfirmation) {
-        throw codes.BadRequest('Passwords do not match.');
       }
 
       return AuthHelper.createPasswordHash(requestObject.password);
@@ -239,7 +236,7 @@ function resetPassword(req, res) {
       {
         params: {
           passwordHash,
-          email: requestObject.email,
+          email,
         },
       },
     ))

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1042,20 +1042,12 @@ definitions:
   ResetPasswordRequest:
     type: object
     required:
-      - email
       - resetPasswordToken
       - password
-      - passwordConfirmation
     additionalProperties: false
     properties:
-      email:
-        type: string
-        format: email
       password:
         type: string
-      passwordConfirmation:
-        type: string
-        description: Same as new password
       resetPasswordToken:
         type: string
         description: Reset token sent through email

--- a/test/api/controllers/accounts.js
+++ b/test/api/controllers/accounts.js
@@ -178,9 +178,7 @@ test.serial('resetPassword: Success updates the password', async (t) => {
     .commit()
     .one();
   const requestAttrs = {
-    email: userAttrs.email,
     password: '123456789test',
-    passwordConfirmation: '123456789test',
     resetPasswordToken: await AuthHelper.createToken({ email: userAttrs.email }),
   };
 


### PR DESCRIPTION
Remove email and password confirmation from the requested payload body, as per #88 and #89.

Fixes #88 
Fixes #89 