### PR TITLE
Accept whitespace in actor autocomplete query string

### DIFF
--- a/api/controllers/actors.js
+++ b/api/controllers/actors.js
@@ -40,9 +40,14 @@ function retrieveActors(swaggerParams, actorClass, edgeToBidClass) {
   let from = actorClass;
   const limit = swaggerParams.limit;
   if (swaggerParams.name) {
-    queryParams.nameQuery = swaggerParams.name;
-    // If the user didn't set fuzziness make this a prefix query
-    if (_.isEmpty(swaggerParams.name.match(/~\d?$/))) {
+    if (swaggerParams.name.match(/~\d?$/)) {
+      // If the user set fuzziness use the raw query
+      queryParams.nameQuery = swaggerParams.name;
+    } else if (swaggerParams.name.match(/\s$/)) {
+      // If the input string ends in whitespace use the raw query
+      queryParams.nameQuery = swaggerParams.name;
+    } else {
+      // Otherwise turn the raw query into a prefix query
       queryParams.nameQuery = `${swaggerParams.name}*`;
     }
     from = `(SELECT *, $score FROM ${actorClass} WHERE name LUCENE :nameQuery)`;

--- a/test/api/controllers/actors.js
+++ b/test/api/controllers/actors.js
@@ -182,6 +182,27 @@ test.serial('getTenderActors allows lucene queries', async (t) => {
   t.deepEqual(await expectedResponse([expectedBuyer]), res.body);
 });
 
+test.serial('getTenderActors ackowledges whitespace in query string', async (t) => {
+  t.plan(2);
+  const expectedBuyer = await fixtures.build('rawBuyer', {
+    name: 'Expelli armus',
+    '@class': 'Buyer',
+  });
+  const alternativeBuyer = await fixtures.build('rawBuyer', {
+    name: 'Expelliarmus',
+    '@class': 'Buyer',
+  });
+  await fixtures.build('rawFullTender', {
+    buyers: [expectedBuyer, alternativeBuyer],
+  }).then((ten) => writers.writeTender(ten));
+
+  const res = await request(app)
+    .get('/tenders/actors?name=expelli%20%20');
+
+  t.is(res.status, codes.SUCCESS);
+  t.deepEqual(await expectedResponse([expectedBuyer]), res.body);
+});
+
 // TODO: Uncomment this after switching to ODB3 SEARCH_CLASS function
 // test.serial('getTenderActors orders suggestions by score', async (t) => {
 //   t.plan(2);


### PR DESCRIPTION
This solves the problem described in #103 by accepting whitespace as part of the autocomplete query and adjusting search result accordingly.

For example, searching for `gas` yields:

```json
[
    {
      "name": "GASTROCENTRUM, spol. s r.o.",
      "id": "SK_body_06488aeebd5d2c4c26494980981fc1c396de03b5616db37122431646832783a4",
      "type": "buyer"
    },
    {
      "name": "SOŠ gastronómie a cestovného ruchu",
      "id": "SK_body_c3abc4d0cd0cd6d1b6e630d3d6c06fb43a8566ac86ea8465d506b74c5ea07325",
      "type": "buyer"
    },
    {
      "name": "GASTRO - HAAL, s.r.o.",
      "id": "SK_body_930b5010c44e83ba1cfc20902a17a6b9b27085175a93f1966a8d5c1b1985caf8",
      "type": "buyer"
    }]
```

whereas searching for `gas ` yields:

```json
[
    {
      "name": "Linde Gas k.s.",
      "id": "EU_body_95787ce9da0ee0bd1dad7a3c8b9cdd9d673d9c74886f3289e3c6ecd4be83bdb0",
      "type": "bidder"
    },
    {
      "name": "Marko Gas, s.r.o.",
      "id": "EU_body_a6ac855f68e076da80866bf917ba173c3165f410c7538e44beb2e2b713a0c84e",
      "type": "bidder"
    },
    {
      "name": "Gas Met s.r.o.",
      "id": "EU_body_f1feeb1986c05efe50c0985cba25f418c1c37d3e5ac30500ebae4631a9a22f56",
      "type": "bidder"
    }]
```