### PR TITLE
Add actor country to autocomplete payload

### DIFF
--- a/api/serializers/actor.js
+++ b/api/serializers/actor.js
@@ -5,11 +5,9 @@ const config = require('../../config/default');
 
 function formatActor(actor) {
   const fields = ['name', 'id'];
-  if (actor['@class'] === 'Buyer') {
-    fields.push('country');
-  }
   const formattedActor = _.pick(actor, fields);
   formattedActor.type = _.toLower(actor['@class']);
+  formattedActor.country = _.get(actor, 'address.country');
   return formattedActor;
 }
 

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1718,6 +1718,9 @@ definitions:
         enum:
           - bidder
           - buyer
+      country:
+        type: string
+        description: Actor country
   Address:
     type: object
     properties:

--- a/test/api/controllers/actors.js
+++ b/test/api/controllers/actors.js
@@ -3,6 +3,7 @@
 const request = require('supertest');
 const test = require('ava').test;
 
+const _ = require('lodash');
 const writers = require('../../../api/writers/tender');
 const codes = require('../../../api/helpers/codes');
 const actorSerializer = require('../../../api/serializers/actor');
@@ -15,7 +16,7 @@ test.afterEach.always(() => helpers.truncateDB());
 
 function expectedResponse(actors) {
   return {
-    actors: actors.map((actor) => actorSerializer.formatActor(actor)),
+    actors: actors.map((actor) => _.omitBy(actorSerializer.formatActor(actor), _.isUndefined)),
   };
 }
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -42,6 +42,9 @@ const buyerAttrs = {
   modified: '2017-06-08T11:55:43.525',
   name: 'Ministry of Magic',
   isPublic: true,
+  address: {
+    country: 'DK',
+  },
 };
 factory.define('rawBuyer', Object, buyerAttrs);
 factory.define('extractedBuyer', Object, buyerAttrs, {
@@ -89,6 +92,9 @@ const bidderAttrs = {
   modified: '2017-11-11T11:55:43.525',
   name: 'Ollivander\'s',
   isPublic: false,
+  address: {
+    country: 'DK',
+  },
 };
 factory.define('rawBidder', Object, bidderAttrs);
 factory.define('extractedBidder', Object, bidderAttrs, {


### PR DESCRIPTION
Providing the country would help users determine if the returned actors and indeed those they were looking for. Therefore the results on `/tenders/actors` now look like this:

```json
   {
      "name": "C-Consulting Lab Technologies s.r.o.",
      "id": "SK_body_cca03aa8bd3124c096c7767bb857305f36411ed2619880b3b60a3e85943dc60c",
      "type": "bidder",
      "country": "SK"
    }
```

This is related to tenders-exposed/elvis-ember#475.

@ca1yps0 Notice the `country` is not a mandatory field for Bidders so make sure you expect and handle the case when the `country` field will be missing for some actors.