### PR TITLE
Map 2003 CPVS to 2007 CPVS

### DIFF
--- a/api/writers/tender.js
+++ b/api/writers/tender.js
@@ -234,11 +234,11 @@ async function upsertBidder(transaction, rawBidder, bidName, rawTender = {}) {
 
 async function upsertCpv(transaction, rawCpv, existingTenderID, tenderName) {
   const cpv = cpvExtractor.extractCpv(rawCpv);
-  if (_.isUndefined(cpv.code) === false) {
-    const cpvName = recordName(cpv.code, 'CPV');
+  if (_.isUndefined(cpv.xOriginalCode) === false) {
+    const cpvName = recordName(cpv.xOriginalCode, 'CPV');
 
     const existingCpv = await config.db.select().from('CPV')
-      .where({ code: cpv.code }).one();
+      .where({ xOriginalCode: cpv.xOriginalCode }).one();
     const existingCpvID = (existingCpv || {})['@rid'];
     if (_.includes(_.flatMap(transaction._state.bcommon, (arr) => arr[0]), cpvName) === false) {
       if (_.isUndefined(existingCpv)) {

--- a/extractors/cpv.js
+++ b/extractors/cpv.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 function extractCpv(cpvAttrs) {
   return {
     xName: cpvAttrs.name,
-    code: extractCpvCode(cpvAttrs.code),
+    xOriginalCode: extractCpvCode(cpvAttrs.code),
     xNumberDigits: cpvAttrs.xNumberDigits,
   };
 }

--- a/extractors/cpv.js
+++ b/extractors/cpv.js
@@ -6,6 +6,8 @@ function extractCpv(cpvAttrs) {
   return {
     xName: cpvAttrs.name,
     xOriginalCode: extractCpvCode(cpvAttrs.code),
+    // Run map_old_cpvs to update this for the old cpvs
+    code: extractCpvCode(cpvAttrs.code),
     xNumberDigits: cpvAttrs.xNumberDigits,
   };
 }

--- a/migrations/m20190608_155918_add_original_code_to_cpv.js
+++ b/migrations/m20190608_155918_add_original_code_to_cpv.js
@@ -1,0 +1,25 @@
+'use strict';
+
+exports.name = 'add original code to CPV';
+
+exports.up = (db) => (
+  db.class.get('CPV')
+    .then((CPV) =>
+      CPV.property.create([
+        {
+          name: 'xOriginalCode',
+          type: 'String',
+          mandatory: true,
+        },
+      ]))
+    .then(() =>
+      db.index.create({
+        name: 'CPV.xOriginalCode',
+        type: 'UNIQUE_HASH_INDEX',
+      }))
+);
+
+exports.down = (db) => (
+  db.class.get('CPV')
+    .then((CPV) => CPV.property.drop('xOriginalCode'))
+);

--- a/migrations/m20190610_145311_remove_mandatory_on_cpv_code.js
+++ b/migrations/m20190610_145311_remove_mandatory_on_cpv_code.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.name = 'remove mandatory on cpv code';
+
+exports.up = (db) => (
+  db.class.get('CPV')
+    .then((CPV) =>
+      CPV.property.update({
+        name: 'code',
+        mandatory: false,
+      })));
+
+exports.down = (db) => (
+  db.class.get('CPV')
+    .then((CPV) =>
+      CPV.property.update({
+        name: 'code',
+        type: 'String',
+        mandatory: true,
+      })));

--- a/migrations/m20190610_150838_update_index_on_cpv_code.js
+++ b/migrations/m20190610_150838_update_index_on_cpv_code.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.name = 'update index on cpv code';
+
+exports.up = (db) => db.index.drop('CPV.code')
+  .then(() => db.index.create({
+    name: 'CPV.code',
+    type: 'NOTUNIQUE_HASH_INDEX',
+  }));
+
+exports.down = (db) => db.index.drop('CPV.code')
+  .then(() => db.index.create({
+    name: 'CPV.code',
+    type: 'UNIQUE_HASH_INDEX',
+  }));

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express-session": "^1.15.6",
     "joi": "^14.3.1",
     "jsonwebtoken": "^8.1.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "mailgun-js": "^0.22.0",
     "moment": "^2.19.1",
     "morgan": "^1.9.1",
@@ -39,7 +39,7 @@
     "passport-local": "^1.0.0",
     "passport-twitter": "^1.0.4",
     "session": "^0.1.0",
-    "swagger-express-mw": "^0.1.0",
+    "swagger-express-mw": "^0.7.0",
     "swagger-ui-express": "^2.0.11",
     "uuid": "^3.1.0",
     "yamljs": "^0.3.0"

--- a/scripts/import_cpvs.js
+++ b/scripts/import_cpvs.js
@@ -18,11 +18,12 @@ function importCPVs() {
       return Promise.map(cpvList, (rawCpv) => {
         const cpv = {
           code: rawCpv.code,
+          xOriginalCode: rawCpv.code,
           xName: rawCpv.text,
           xNumberDigits: rawCpv.number_digits,
         };
         return config.db.select().from('CPV')
-          .where({ code: cpv.code })
+          .where({ xOriginalCode: cpv.code })
           .one()
           .then((existingCpv) => {
             if (_.isUndefined(existingCpv)) {

--- a/scripts/map_old_cpvs.js
+++ b/scripts/map_old_cpvs.js
@@ -19,12 +19,15 @@ function mapOldCPVs() {
 
       return helpers.fetchRemoteFile(correspondenceURL)
         .then((correspondenceList) => {
-          const withCorrespondence = _.reject(correspondenceList, (code) => _.isNull(code.code_2003));
+          const withCorrespondence = _.reject(
+            correspondenceList,
+            (code) => _.isNull(code.code_2003),
+          );
           const groupedBy2003Cpv = _.groupBy(withCorrespondence, 'code_2003');
           const cpvList2003 = _.keys(groupedBy2003Cpv);
 
           return Promise.map(cpvList2003, (cpv2003) => {
-            const group = groupedBy2003Cpv[cpv2003]
+            const group = groupedBy2003Cpv[cpv2003];
             // Always map to the most general 2007 CPV
             const cpv2007 = _.first(_.sortBy(group, 'code_2007'));
             const standardCpv = standardCpvs[cpv2007.code_2007][0];
@@ -51,7 +54,7 @@ function mapOldCPVs() {
                   .return('AFTER')
                   .commit()
                   .one();
-              })
+              });
           });
         });
     })

--- a/scripts/map_old_cpvs.js
+++ b/scripts/map_old_cpvs.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+const _ = require('lodash');
+const { URL } = require('url');
+const Promise = require('bluebird');
+
+const config = require('../config/default');
+const helpers = require('./helpers');
+
+const correspondenceURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpvs_2003_2007_correspondence.json');
+const standardCpvsURL = new URL('https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpv_codes.json');
+
+function mapOldCPVs() {
+  return helpers.fetchRemoteFile(standardCpvsURL)
+    .then((standardCpvsList) => {
+      const standardCpvs = _.groupBy(standardCpvsList, 'code');
+
+      return helpers.fetchRemoteFile(correspondenceURL)
+        .then((correspondenceList) => {
+          const withCorrespondence = _.reject(correspondenceList, (code) => _.isNull(code.code_2003));
+          const groupedBy2003Cpv = _.groupBy(withCorrespondence, 'code_2003');
+          const cpvList2003 = _.keys(groupedBy2003Cpv);
+
+          return Promise.map(cpvList2003, (cpv2003) => {
+            const group = groupedBy2003Cpv[cpv2003]
+            // Always map to the most general 2007 CPV
+            const cpv2007 = _.first(_.sortBy(group, 'code_2007'));
+            const standardCpv = standardCpvs[cpv2007.code_2007][0];
+            const mappedCpv = {
+              code: standardCpv.code,
+              xOriginalCode: cpv2003,
+              xName: standardCpv.text,
+              xNumberDigits: standardCpv.number_digits,
+            };
+            // console.log(mappedCpv);
+            return config.db.select().from('CPV')
+              .where({ xOriginalCode: cpv2003 })
+              .one()
+              .then((existingCpv) => {
+                if (_.isUndefined(existingCpv)) {
+                  return config.db.create('vertex', 'CPV')
+                    .set(mappedCpv)
+                    .commit()
+                    .one();
+                }
+                return config.db.update('CPV')
+                  .set(mappedCpv)
+                  .where({ '@rid': existingCpv['@rid'] })
+                  .return('AFTER')
+                  .commit()
+                  .one();
+              })
+          });
+        });
+    })
+    .then((mappedCPVs) => {
+      console.log(`Processed ${mappedCPVs.length} 2003 CPVs`);
+      process.exit();
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(-1);
+    });
+}
+
+mapOldCPVs();

--- a/test/api/controllers/years.js
+++ b/test/api/controllers/years.js
@@ -39,7 +39,7 @@ test.serial('getTenderYears filters years by cpvs', async (t) => {
   t.plan(2);
   const expectedYear = 2018;
   const alternativeYear = 2016;
-  const cpv = await fixtures.build('rawCpv');
+  const cpv = await fixtures.build('rawCpv', { code: '09132100' });
   await fixtures.build('rawLotWithBid', {
     awardDecisionDate: `${expectedYear}-01-17`,
   }).then((lot) => fixtures.build('rawFullTender', {

--- a/test/api/writers/network.js
+++ b/test/api/writers/network.js
@@ -57,7 +57,6 @@ test.serial('createNetwork filters bids by query', async (t) => {
   const queryBidder = await fixtures.build('rawBidder');
   const bidders = await fixtures.buildMany('rawBidder', 2);
   const buyer = await fixtures.build('rawBuyer');
-  const queryCpv = await fixtures.build('rawCpv');
   const queryYear = 2017;
   const queryCountry = 'CZ';
   await fixtures.build('rawBidWithBidder', { bidders })
@@ -68,7 +67,6 @@ test.serial('createNetwork filters bids by query', async (t) => {
     .then((rawLot) => fixtures.build('rawTender', {
       buyers: [queryBuyer],
       lots: [rawLot],
-      cpvs: [queryCpv],
       country: queryCountry,
     }))
     .then((rawTender) => tenderWriters.writeTender(rawTender));
@@ -80,7 +78,6 @@ test.serial('createNetwork filters bids by query', async (t) => {
     .then((rawLot) => fixtures.build('rawTender', {
       buyers: [buyer],
       lots: [rawLot],
-      cpvs: [queryCpv],
       country: queryCountry,
     }))
     .then((rawTender) => tenderWriters.writeTender(rawTender));
@@ -91,7 +88,6 @@ test.serial('createNetwork filters bids by query', async (t) => {
   const networkParams = {
     query: {
       countries: [queryCountry],
-      cpvs: [queryCpv.code],
       years: [queryYear],
       buyers: [queryBuyer.id],
       bidders: [queryBidder.id],

--- a/test/api/writers/tender.js
+++ b/test/api/writers/tender.js
@@ -426,7 +426,7 @@ test.serial('upsertCpv updates the edge between existing CPV and existing tender
     .one();
   const updatedCpvAttrs = await fixtures.build('rawCpv', {
     isMain: false,
-    code: existingCpv.code,
+    code: existingCpv.xOriginalCode,
   });
   const tenderName = 'tender';
   const transaction = await config.db.let(tenderName, (tr) =>
@@ -466,7 +466,7 @@ test.serial('upsertCpv allows cpv to have edges to more than one tender', async 
         .return(`$${secondTenderName}`)
         .one()));
   const writtenCpv = await config.db.select().from('CPV')
-    .where({ code: rawCpv.code })
+    .where({ xOriginalCode: rawCpv.code })
     .one();
   const writtenEdges = await config.db.select().from('HasCPV')
     .where({ in: writtenCpv['@rid'] })


### PR DESCRIPTION
Maps 2003 cpvs to 2007 cpvs based on the mapping [here](https://raw.githubusercontent.com/tenders-exposed/data_sources/master/cpvs_2003_2007_correspondence.json). The mapping is based on an excel files provided by the EU.

This adds a new field called `xOriginalCpv` to the `CPV` vertex.  The old CPV is stored in `xOriginalCpv` and the corresponding new CPV is added in the `code`. This means everything else stays the same. We will query them as we normally would all the other cpvs and these tenders will show up in searches based on their 2007 cpv. 


Solves #110 