### PR TITLE
Switch to PM2 as a process manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY package*.json ./
 
 # Install deps
 RUN npm install --only=production
+RUN npm install -g pm2
 
 COPY . ./
 
@@ -15,4 +16,4 @@ ENV HOST 0.0.0.0
 ENV PORT 10010
 
 EXPOSE $PORT
-CMD ["npm", "start"]
+CMD [ "pm2-runtime", "--name", "api", "--raw", "--only", "API", "server.js" ]


### PR DESCRIPTION
This is a first step to better monitoring and handling of system signals.

In order to properly handle, for example, a `SIGKILL`, we need to start the app with `CMD ["node", "server.js"]`. NPM is not properly wired to handle forwarding such events to the underlying app.

However, by using a process manager that is equipped for this, we also gain flexibility over logging and some soft scaling (we can scale number of workers inside a container). The scaling is hopefully not going to be used this way, but it's an extra lever to pull in case of trouble.

The future of this might be k8s, in which case formatting the logs and managing health checks from a single configuration point will make things easier to maintain.

And last but not least re: k8s, if the app dies, the container does not get killed and recreated like nothing happened. The process inside it will be restarted by pm2 and the container will be around for post mortem in a `Running` state as opposed to being `Evicted`. This is so much easier to debug.

I know there are pros and cons related to using a process manager inside Docker containers. However, we were using `npm` prior to this, and npm is nothing else but a opaque process manager that doesn't intermediate well between system and worker process.

This is a drop in replacement for what we had, nothing changes in terms of usage or deployment.